### PR TITLE
Fix mergeObjects function

### DIFF
--- a/Resources/Public/JavaScript/ModuleDataListing.js
+++ b/Resources/Public/JavaScript/ModuleDataListing.js
@@ -259,15 +259,15 @@ define([
 	ModuleDataListing.utility = {
 		// Filter setup
 		mergeObjects: function (obj1, obj2) {
-			const result = { ...obj1 };
+			const result = JSON.parse(JSON.stringify(obj1));
 
 			for (let key in obj2) {
-				if (obj2.hasOwnProperty(key)) {
-					if (obj2[key] instanceof Object && obj1[key] instanceof Object) {
-						result[key] = ModuleDataListing.utility.mergeObjects(obj1[key], obj2[key]);
-					} else {
-						result[key] = obj2[key];
-					}
+				if (obj2[key] instanceof Array && obj1[key] instanceof Array) {
+					result[key] = obj2[key];
+				} else if (obj2[key] instanceof Object && obj1[key] instanceof Object) {
+					result[key] = ModuleDataListing.utility.mergeObjects(obj1[key], obj2[key]);
+				} else {
+					result[key] = obj2[key];
 				}
 			}
 


### PR DESCRIPTION
There area a few issues with the `mergeObjects` function;
* When it merges array's it converts them to objects
* The results object is only a shallow copy of obj1
* The check for `obj2.hasOwnProperty(key)` is redundant as we get `key` out of `obj2`. If this was not the desired result, we likely want to iterate over `Object.getOwnPropertyNames(obj2)`.

Here are some jsfiddle examples of each point;

* [`[] instanceof Object` returns unexpected value](https://jsfiddle.net/sthnx1v5/6/)
* [The spread operator is not sufficient for a deep clone](https://jsfiddle.net/1zwpakor/)
* [`hasOwnProperty` probably isn't that useful](https://jsfiddle.net/f4L1yps7/)

This PR rectifies these issues.